### PR TITLE
rename to cf-service-connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cf-db-connect*
+cf-service-connect*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,4 +39,4 @@ This will (re)install then run the plugin, all in one.
     ```
 
 1. Commit, tag, and push via Git.
-1. Upload the binaries to [the new Release](https://github.com/18F/cf-db-connect/releases).
+1. Upload the binaries to [the new Release](https://github.com/18F/cf-service-connect/releases).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Cloud Foundry CLI Database Connection Plugin [![Build Status](https://travis-ci.org/18F/cf-db-connect.svg?branch=master)](https://travis-ci.org/18F/cf-db-connect) [![Code Climate](https://codeclimate.com/github/18F/cf-db-connect/badges/gpa.svg)](https://codeclimate.com/github/18F/cf-db-connect)
+# Cloud Foundry CLI Service Connection Plugin [![Build Status](https://travis-ci.org/18F/cf-service-connect.svg?branch=master)](https://travis-ci.org/18F/cf-service-connect) [![Code Climate](https://codeclimate.com/github/18F/cf-service-connect/badges/gpa.svg)](https://codeclimate.com/github/18F/cf-service-connect)
 
-This plugin makes it easy to connect to your databases in Cloud Foundry from your local machine. This condenses the steps listed in [Accessing Services with SSH](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-services.html) to a single command. Requires Diego architecture with [SSH enabled](https://docs.cloudfoundry.org/running/config-ssh.html).
+This plugin makes it easy to connect to your databases or other Cloud Foundry service instances from your local machine. This condenses the steps listed in [Accessing Services with SSH](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-services.html) to a single command. Requires Diego architecture with [SSH enabled](https://docs.cloudfoundry.org/running/config-ssh.html).
 
 ## Support
 
@@ -9,20 +9,20 @@ Currently supports (most) service brokers for the following:
 * MySQL
 * PostgreSQL
 
-Doesn't run on Windows [yet](https://github.com/18F/cf-db-connect/issues/13).
+Doesn't run on Windows [yet](https://github.com/18F/cf-service-connect/issues/13).
 
 ## Local installation
 
 1. Install the Cloud Foundry CLI v6.15.0 or later.
-1. Install the plugin, using the appropriate binary URL from [the Releases page](https://github.com/18F/cf-db-connect/releases).
+1. Install the plugin, using the appropriate binary URL from [the Releases page](https://github.com/18F/cf-service-connect/releases).
 
     ```sh
     cf install-plugin <binary_url>
     # will be of the format
-    # https://github.com/18F/cf-db-connect/releases/download/<version>/cf-db-connect_<os>_<arch>
+    # https://github.com/18F/cf-service-connect/releases/download/<version>/cf-service-connect_<os>_<arch>
     ```
 
-1. Install `psql` or `mysql` (depending on which database you need to connect to).
+1. Install `psql` or `mysql` (depending on which you need to connect to).
 
 ## Usage
 
@@ -31,7 +31,7 @@ Doesn't run on Windows [yet](https://github.com/18F/cf-db-connect/issues/13).
 
 ```
 $ cf target --organization <org> --space <space>
-$ cf connect-to-db <app_name> <service_instance_name>
+$ cf connect-to-service <app_name> <service_instance_name>
 Finding the service instance details...
 Setting up SSH tunnel...
 ...

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/18F/cf-db-connect/launcher"
-	"github.com/18F/cf-db-connect/models"
-	"github.com/18F/cf-db-connect/service"
+	"github.com/18F/cf-service-connect/launcher"
+	"github.com/18F/cf-service-connect/models"
+	"github.com/18F/cf-service-connect/service"
 
 	"code.cloudfoundry.org/cli/plugin"
 )

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/18F/cf-db-connect
+package: github.com/18F/cf-service-connect
 import:
 - package: code.cloudfoundry.org/cli
   version: v6.x.x

--- a/launcher/exec.go
+++ b/launcher/exec.go
@@ -1,7 +1,7 @@
 package launcher
 
 import (
-	"github.com/18F/cf-db-connect/logger"
+	"github.com/18F/cf-service-connect/logger"
 	"os/exec"
 	"strings"
 )

--- a/launcher/ssh_tunnel.go
+++ b/launcher/ssh_tunnel.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/18F/cf-db-connect/models"
+	"github.com/18F/cf-service-connect/models"
 	"github.com/phayes/freeport"
 )
 

--- a/main.go
+++ b/main.go
@@ -5,18 +5,18 @@ import (
 	"flag"
 	"log"
 
-	"github.com/18F/cf-db-connect/connector"
+	"github.com/18F/cf-service-connect/connector"
 
 	"code.cloudfoundry.org/cli/plugin"
 )
 
-const SUBCOMMAND = "connect-to-db"
+const subcommand = "connect-to-service"
 
-// DBConnectPlugin is the struct implementing the interface defined by the core CLI. It can
+// ServiceConnectPlugin is the struct implementing the interface defined by the core CLI. It can
 // be found at  "code.cloudfoundry.org/cli/plugin/plugin.go"
-type DBConnectPlugin struct{}
+type ServiceConnectPlugin struct{}
 
-func (c *DBConnectPlugin) parseOptions(args []string) (options connector.Options, err error) {
+func (c *ServiceConnectPlugin) parseOptions(args []string) (options connector.Options, err error) {
 	metadata := c.GetMetadata()
 	command := metadata.Commands[0]
 	flags := flag.NewFlagSet(command.Name, flag.ExitOnError)
@@ -47,9 +47,9 @@ func (c *DBConnectPlugin) parseOptions(args []string) (options connector.Options
 // be used to invoke cli commands. The second paramter, args, is a slice of
 // strings. args[0] will be the name of the command, and will be followed by
 // any additional arguments a cli user typed in.
-func (c *DBConnectPlugin) Run(cliConnection plugin.CliConnection, args []string) {
+func (c *ServiceConnectPlugin) Run(cliConnection plugin.CliConnection, args []string) {
 	// check to ensure it's the right subcommand, not others like CLI-MESSAGE-UNINSTALL
-	if args[0] != SUBCOMMAND {
+	if args[0] != subcommand {
 		return
 	}
 
@@ -64,9 +64,10 @@ func (c *DBConnectPlugin) Run(cliConnection plugin.CliConnection, args []string)
 	}
 }
 
-func (c *DBConnectPlugin) GetMetadata() plugin.PluginMetadata {
+// GetMetadata returns the plugin information for the CLI to consume.
+func (c *ServiceConnectPlugin) GetMetadata() plugin.PluginMetadata {
 	return plugin.PluginMetadata{
-		Name: "DBConnect",
+		Name: "ServiceConnect",
 		Version: plugin.VersionType{
 			Major: 1,
 			Minor: 0,
@@ -79,10 +80,10 @@ func (c *DBConnectPlugin) GetMetadata() plugin.PluginMetadata {
 		},
 		Commands: []plugin.Command{
 			{
-				Name:     SUBCOMMAND,
+				Name:     subcommand,
 				HelpText: "Open a shell that's connected to a database service instance",
 				UsageDetails: plugin.Usage{
-					Usage: "\n   cf " + SUBCOMMAND + " [-no-client] <app_name> <service_instance_name>",
+					Usage: "\n   cf " + subcommand + " [-no-client] <app_name> <service_instance_name>",
 					Options: map[string]string{
 						"no-client": "If this param is passed, the CLI client for the service won't be started, and the connection information will be printed to the console. Useful for connecting to the service through a GUI.",
 					},
@@ -93,5 +94,5 @@ func (c *DBConnectPlugin) GetMetadata() plugin.PluginMetadata {
 }
 
 func main() {
-	plugin.Start(new(DBConnectPlugin))
+	plugin.Start(new(ServiceConnectPlugin))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/18F/cf-db-connect/connector"
+	"github.com/18F/cf-service-connect/connector"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +17,7 @@ type parseOptionsTest struct {
 func TestParseOptions(t *testing.T) {
 	tests := []parseOptionsTest{
 		{
-			"connect-to-db app service",
+			"connect-to-service app service",
 			false,
 			connector.Options{
 				"app",
@@ -26,7 +26,7 @@ func TestParseOptions(t *testing.T) {
 			},
 		},
 		{
-			"connect-to-db -no-client app service",
+			"connect-to-service -no-client app service",
 			false,
 			connector.Options{
 				"app",
@@ -35,13 +35,13 @@ func TestParseOptions(t *testing.T) {
 			},
 		},
 		{
-			"connect-to-db foo bar baz",
+			"connect-to-service foo bar baz",
 			true,
 			connector.Options{},
 		},
 	}
 
-	plugin := DBConnectPlugin{}
+	plugin := ServiceConnectPlugin{}
 	for _, test := range tests {
 		args := strings.Split(test.args, " ")
 		opts, err := plugin.parseOptions(args)

--- a/models/service_key.go
+++ b/models/service_key.go
@@ -37,7 +37,7 @@ func (sk *ServiceKey) GetCreds(cliConnection plugin.CliConnection) (creds Creden
 
 func generateServiceKeyID() string {
 	// TODO find one that's available, or randomize
-	return "DB_CONNECT"
+	return "SERVICE_CONNECT"
 }
 
 func NewServiceKey(instance ServiceInstance) ServiceKey {

--- a/run.sh
+++ b/run.sh
@@ -3,8 +3,8 @@
 set -e
 set -x
 
-NAME=DBConnect
-SUBCOMMAND=connect-to-db
+NAME=ServiceConnect
+SUBCOMMAND=connect-to-service
 
 # http://stackoverflow.com/a/1371283/358804
 BIN=${PWD##*/}

--- a/service/mysql.go
+++ b/service/mysql.go
@@ -3,8 +3,8 @@ package service
 import (
 	"strconv"
 
-	"github.com/18F/cf-db-connect/launcher"
-	"github.com/18F/cf-db-connect/models"
+	"github.com/18F/cf-service-connect/launcher"
+	"github.com/18F/cf-service-connect/models"
 )
 
 type mySQL struct{}

--- a/service/mysql_test.go
+++ b/service/mysql_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	"github.com/18F/cf-db-connect/models"
+	"github.com/18F/cf-service-connect/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/service/psql.go
+++ b/service/psql.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/18F/cf-db-connect/launcher"
-	"github.com/18F/cf-db-connect/logger"
-	"github.com/18F/cf-db-connect/models"
+	"github.com/18F/cf-service-connect/launcher"
+	"github.com/18F/cf-service-connect/logger"
+	"github.com/18F/cf-service-connect/models"
 )
 
 type pSQL struct{}

--- a/service/psql_test.go
+++ b/service/psql_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	"github.com/18F/cf-db-connect/models"
+	"github.com/18F/cf-service-connect/models"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/service/services.go
+++ b/service/services.go
@@ -1,6 +1,6 @@
 package service
 
-import "github.com/18F/cf-db-connect/models"
+import "github.com/18F/cf-service-connect/models"
 
 type Service interface {
 	Match(si models.ServiceInstance) bool

--- a/service/services_test.go
+++ b/service/services_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	"github.com/18F/cf-db-connect/models"
+	"github.com/18F/cf-service-connect/models"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Per wise suggestion from @mogul in https://github.com/18F/cf-db-connect/issues/17#issuecomment-270210857. The plugin could (eventually) be useful for other services, like queues, etc.

## Before merging

* [x] Rename repository
* [x] Ensure Travis CI is still working
* [x] Ensure Code Climate is still working
* [x] Ensure binary still builds