### PR TITLE
bump version to 1.1.0; remove windows warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Currently supports (most) service brokers for the following:
 * PostgreSQL (requires `psql` CLI)
 * Redis (requires `redis-cli`)
 
-Doesn't run on Windows [yet](https://github.com/18F/cf-service-connect/issues/13).
-
 ## Local installation
 
 1. Install the Cloud Foundry CLI v6.15.0 or later.

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func (c *ServiceConnectPlugin) GetMetadata() plugin.PluginMetadata {
 		Name: "ServiceConnect",
 		Version: plugin.VersionType{
 			Major: 1,
-			Minor: 0,
+			Minor: 1,
 			Build: 0,
 		},
 		MinCliVersion: plugin.VersionType{


### PR DESCRIPTION
I want to cut a new release with windows builds to fix #13 since this works fine on windows.